### PR TITLE
Use fundingcircle/jackdaw instead of appsflyer/ketu

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :java-source-paths ["src/java" "src/java/generated"]
   :dependencies [; Core clojure
                  [org.clojure/clojure "1.10.3"]
-                 [org.clojure/core.async "1.5.640"]
+                 [org.clojure/core.async "1.5.640" :exclusions [org.clojure/tools.reader]]
 
                  ; Async
                  [funcool/promesa "6.0.2"]
@@ -21,8 +21,8 @@
                  [commons-codec/commons-codec "1.15"]
 
                  ; HTTP server
-                 [com.appsflyer/donkey "0.5.1"]
-                 [metosin/reitit "0.5.15"]
+                 [com.appsflyer/donkey "0.5.1" :exclusions [metosin/jsonista]]
+                 [metosin/reitit "0.5.15" :exclusions [org.clojure/tools.reader]]
                  [ring/ring-core "1.9.4"]
 
                  ; State management
@@ -34,14 +34,21 @@
                  [nonseldiha/slf4j-mulog "0.2.1"]
 
                  ; Kafka messaging
-                 [com.appsflyer/ketu "0.6.0"]
+                 [fundingcircle/jackdaw "0.9.1" :exclusions [io.netty/*
+                                                             metosin/jsonista
+                                                             org.clojure/core.cache
+                                                             org.apache.kafka/kafka-clients
+                                                             joda-time]]
+                 [org.apache.kafka/kafka-clients "2.8.0"]   ; This is here to resolve a jackdaw conflict
+                 [joda-time "2.10.13"]                      ; This is here to resolve a jackdaw conflict
 
                  ; Protobuf
                  [com.google.protobuf/protobuf-java ~proto-version]
-                 [com.appsflyer/pronto "2.0.9"]
+                 [com.appsflyer/pronto "2.0.9" :exclusions [riddley]]
 
                  ; Other
                  [danlentz/clj-uuid "0.1.9"]]
+  :pedantic? :abort
   :main ^:skip-aot sample-donkey-api.core
   :target-path "target/%s"
   :lein-protodeps {:output-path   "src/java/generated"
@@ -60,9 +67,14 @@
                                       [com.appsflyer/lein-protodeps "1.0.2"]]
                        :dependencies [[clj-kondo "2021.10.19"]
                                       [criterium "0.4.6"]
-                                      [org.testcontainers/kafka "1.16.2"]
-                                      [clj-test-containers "0.5.0"]
-                                      [metosin/jsonista "0.3.4"]]
+
+                                      ; Code coverage
+                                      [cloverage "1.2.2" :exclusions [org.clojure/tools.reader
+                                                                      org.clojure/tools.logging]]
+
+                                      ; test containers
+                                      [clj-test-containers "0.5.0" :exclusions [org.testcontainers/testcontainers]]
+                                      [org.testcontainers/kafka "1.16.2" :exclusions [org.slf4j/slf4j-api]]]
                        :eftest       {:multithread?    false
                                       :capture-output? false
                                       :report          eftest.report.junit/report

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,9 +2,10 @@
                :internal {:port #dyn/long #dyn/prop ["INTERNAL_PORT" "8081"]}}
  :ip-resolver {:access-key   #dyn/prop IP_STACK_ACCESS_KEY
                :url-template "http://api.ipstack.com/%s?access_key=%s&output=json&fields=country_code,region_code,latitude,longitude,continent_code"}
- :kafka       {:stock-order {:producer {:config                {:name       "stocks-order-producer"
-                                                                :brokers    #dyn/prop "KAFKA_BROKERS"
-                                                                :topic      "stocks_orders"
-                                                                :value-type :byte-array
-                                                                :shape      :value}
-                                        :channel-size-per-core #dyn/long #dyn/prop ["CHANNEL_SIZE_PER_CORE" "250"]}}}}
+ :kafka       {:stock-order {:producer {:config {"bootstrap.servers" #dyn/prop "KAFKA_BROKERS"
+                                                 "key.serializer"    "org.apache.kafka.common.serialization.ByteArraySerializer"
+                                                 "value.serializer"  "org.apache.kafka.common.serialization.ByteArraySerializer"
+                                                 "acks"              "1"
+                                                 "compression.type"  "gzip"
+                                                 "client.id"         "stocks-order-producer"}
+                                        :topic  "stocks_orders"}}}}

--- a/src/sample_donkey_api/application/protocols.clj
+++ b/src/sample_donkey_api/application/protocols.clj
@@ -8,5 +8,5 @@
   (resolve-ip [this ip] "Returns the resolved IP as a Future of a map, or a completed Future"))
 
 (defprotocol IMessagePublisher
-  (publish [this message] "Publishes an event, expected to return true if accepted")
+  (publish-stock-order [this stock-order-proto-bytes] "Publish a stock order event, expected to return a truthy promise")
   (close! [this] "Closes the output"))

--- a/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
+++ b/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
@@ -1,25 +1,28 @@
 (ns sample-donkey-api.infrastructure.repository.kafka-producer
   (:require [sample-donkey-api.application.protocols :as protocols]
-            [ketu.async.sink :as sink]
-            [clojure.core.async :as async]
-            [integrant.core :as ig]))
+            [jackdaw.client :as jc]
+            [integrant.core :as ig]
+            [promesa.core :as p])
+  (:import (org.apache.kafka.clients.producer Producer ProducerRecord)
+           (java.time Duration)))
 
-(deftype ^:private KafkaProducer [channel producer]
+(defn- bytes->ProducerRecord [topic-name ^bytes message-bytes]
+  (ProducerRecord. topic-name message-bytes))
+
+(deftype ^:private KafkaProducer [producer bytes->ProducerRecord-fn]
   protocols/IMessagePublisher
-  (publish [_ message]
-    (async/offer! channel message))
+  (publish-stock-order [_ message-bytes]
+    (-> (jc/send! producer ^ProducerRecord (bytes->ProducerRecord-fn message-bytes))
+        (p/then (constantly true))))
   (close! [_]
-    (async/close! channel)))
+    (.close ^Producer producer (Duration/ofSeconds 5))))
 
-(defn- create-kafka-producer [producer-config producer-channel-size-per-core]
-  (let [available-processors (.availableProcessors (Runtime/getRuntime))
-        channel-size         (* available-processors producer-channel-size-per-core)
-        in-channel           (async/chan channel-size)]
-    (KafkaProducer. in-channel (sink/sink in-channel producer-config))))
+(defn- create-kafka-producer [stock-order-producer]
+  (let [producer (jc/producer (:config stock-order-producer))]
+    (KafkaProducer. producer (partial bytes->ProducerRecord (:topic stock-order-producer)))))
 
 (defmethod ig/init-key :repository/stock-order-producer [_ {:keys [config]}]
-  (create-kafka-producer (-> config :kafka :stock-order :producer :config)
-                         (-> config :kafka :stock-order :producer :channel-size-per-core)))
+  (create-kafka-producer (-> config :kafka :stock-order :producer)))
 
 (defmethod ig/halt-key! :repository/stock-order-producer [_ kafka-producer]
   (protocols/close! kafka-producer))

--- a/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
+++ b/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
@@ -12,8 +12,8 @@
 (deftype ^:private KafkaProducer [producer bytes->ProducerRecord-fn]
   protocols/IMessagePublisher
   (publish-stock-order [_ message-bytes]
-    (-> (jc/send! producer ^ProducerRecord (bytes->ProducerRecord-fn message-bytes))
-        (p/then (constantly true))))
+    (jc/send! producer ^ProducerRecord (bytes->ProducerRecord-fn message-bytes))
+    (p/resolved true))
   (close! [_]
     (.close ^Producer producer (Duration/ofSeconds 5))))
 

--- a/test/sample_donkey_api/integration/containers/kafka_setup.clj
+++ b/test/sample_donkey_api/integration/containers/kafka_setup.clj
@@ -2,7 +2,8 @@
   (:require [com.brunobonacci.mulog :as logger]
             [clj-test-containers.core :as tc]
             [clj-uuid :as uuid]
-            [ketu.async.source :as source])
+            [jackdaw.client :as jc]
+            [clojure.core.async :as async])
   (:import (org.testcontainers.containers KafkaContainer)
            (org.testcontainers.utility DockerImageName)))
 
@@ -14,23 +15,40 @@
 
 (defn start-container []
   (logger/log ::creating-kafka-container)
-  (let [container (-> {:container     (KafkaContainer. (DockerImageName/parse "confluentinc/cp-kafka:5.5.3"))
+  (let [container (-> {:container     (KafkaContainer. (DockerImageName/parse "confluentinc/cp-kafka:6.1.1"))
                        :exposed-ports [container-port]}
                       tc/init
                       tc/start!)]
     (reset! kafka-container container)))
 
-(defn start-consuming [channel topic]
-  (let [consumer-id (str "test-consumer-" (uuid/v4))]
-    (source/source
-      channel
-      {:name            consumer-id
-       :topic           topic
-       :group-id        consumer-id
-       :brokers         (get-bootstrap-servers @kafka-container)
-       :value-type      :byte-array
-       :shape           :value
-       :internal-config {"auto.offset.reset" "earliest"}})))
+(defn- poll-and-loop!
+  [consumer processing-fn continue?]
+  (let [poll-ms 200]
+    (loop []
+      (when (true? @continue?)
+        (let [records (jc/poll consumer poll-ms)]
+          (when (seq records)
+            (doseq [record records]
+              (processing-fn record))
+            (.commitSync consumer))
+          (recur))))))
 
-(defn stop-consuming! [consumer]
-  (source/stop! consumer))
+(defn- process-messages! [continue? consumer-config topic-name processing-fn]
+  (future
+    (with-open [consumer (jc/subscribed-consumer consumer-config [{:topic-name topic-name}])]
+      (poll-and-loop! consumer processing-fn continue?))))
+
+(defn start-consuming
+  "Starting consumption from the `topic` topic, putting the value of the records into the `channel` channel.
+   Returns a functions to stop the consumer."
+  [channel topic]
+  (let [continue?       (atom true)
+        consumer-id     (str "test-consumer-" (uuid/v4))
+        consumer-config {"bootstrap.servers"  (get-bootstrap-servers @kafka-container)
+                         "group.id"           consumer-id
+                         "key.deserializer"   "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+                         "value.deserializer" "org.apache.kafka.common.serialization.ByteArrayDeserializer"}]
+    (process-messages! continue? consumer-config topic #(async/>!! channel %))
+    (fn stop-consuming! []
+      (reset! continue? false)
+      (Thread/sleep 200))))

--- a/test/sample_donkey_api/integration/external_server.clj
+++ b/test/sample_donkey_api/integration/external_server.clj
@@ -40,7 +40,7 @@
   If the value does not come in during that period, returns :timed-out. If
   milliseconds is not given, a default of 1000 is used."
   ([chan]
-   (<!!? chan 1000))
+   (<!!? chan 2000))
   ([chan milliseconds]
    (let [timeout (async/timeout milliseconds)
          [value port] (async/alts!! [chan timeout])]

--- a/test/sample_donkey_api/integration/message_consumers.clj
+++ b/test/sample_donkey_api/integration/message_consumers.clj
@@ -7,10 +7,12 @@
   (:import (stocks StocksOuterClass$StockOrder)))
 
 (def stock-order-channel (async/chan 100
-                                     (map #(pronto/bytes->proto-map proto-defs/proto-mapper StocksOuterClass$StockOrder %))
+                                     (comp
+                                       (map :value)
+                                       (map #(pronto/bytes->proto-map proto-defs/proto-mapper StocksOuterClass$StockOrder %)))
                                      #(logger/log ::error-mapping-kafka-message :exception %)))
 
 (defn with-kafka-consumers [test-fn]
-  (let [stock-order-consumer (kafka-setup/start-consuming stock-order-channel "stocks_orders")]
+  (let [stop-consuming! (kafka-setup/start-consuming stock-order-channel "stocks_orders")]
     (test-fn)
-    (kafka-setup/stop-consuming! stock-order-consumer)))
+    (stop-consuming!)))


### PR DESCRIPTION
- Use `:pedantic? :abort`
- Resolve dependency conflicts
- Update the config to a raw Kafka producer style
- kafka-procuer will now return a Future when the message is sent, the controller will now wait for it to respond back to the client
- Remove the redundant `:resource-exhausted` response code
- Use a more specific `publish-stock-order` function instead of the too-generic `publish` (to which topic/queue?)