### PR TITLE
Avoid thread context switches in the main flow

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
   :java-source-paths ["src/java" "src/java/generated"]
   :dependencies [; Core clojure
                  [org.clojure/clojure "1.10.3"]
-                 [org.clojure/core.async "1.5.640"]
+                 [org.clojure/core.async "1.5.640" :exclusions [org.clojure/tools.reader]]
 
                  ; Async
                  [funcool/promesa "6.0.2"]
@@ -21,8 +21,8 @@
                  [commons-codec/commons-codec "1.15"]
 
                  ; HTTP server
-                 [com.appsflyer/donkey "0.5.1"]
-                 [metosin/reitit "0.5.15"]
+                 [com.appsflyer/donkey "0.5.1" :exclusions [metosin/jsonista]]
+                 [metosin/reitit "0.5.15" :exclusions [org.clojure/tools.reader]]
                  [ring/ring-core "1.9.4"]
 
                  ; State management
@@ -34,14 +34,15 @@
                  [nonseldiha/slf4j-mulog "0.2.1"]
 
                  ; Kafka messaging
-                 [com.appsflyer/ketu "0.6.0"]
+                 [com.appsflyer/ketu "0.6.0" :exclusions [expound]]
 
                  ; Protobuf
                  [com.google.protobuf/protobuf-java ~proto-version]
-                 [com.appsflyer/pronto "2.0.9"]
+                 [com.appsflyer/pronto "2.0.9" :exclusions [riddley]]
 
                  ; Other
                  [danlentz/clj-uuid "0.1.9"]]
+  :pedantic? :abort
   :main ^:skip-aot sample-donkey-api.core
   :target-path "target/%s"
   :lein-protodeps {:output-path   "src/java/generated"
@@ -60,9 +61,13 @@
                                       [com.appsflyer/lein-protodeps "1.0.2"]]
                        :dependencies [[clj-kondo "2021.10.19"]
                                       [criterium "0.4.6"]
-                                      [org.testcontainers/kafka "1.16.2"]
-                                      [clj-test-containers "0.5.0"]
-                                      [metosin/jsonista "0.3.4"]]
+
+                                      ; Code coverage
+                                      [cloverage "1.2.2" :exclusions [org.clojure/tools.reader]]
+
+                                      ; test containers
+                                      [clj-test-containers "0.5.0" :exclusions [org.testcontainers/testcontainers]]
+                                      [org.testcontainers/kafka "1.16.2" :exclusions [org.slf4j/slf4j-api]]]
                        :eftest       {:multithread?    false
                                       :capture-output? false
                                       :report          eftest.report.junit/report

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -2,9 +2,10 @@
                :internal {:port #dyn/long #dyn/prop ["INTERNAL_PORT" "8081"]}}
  :ip-resolver {:access-key   #dyn/prop IP_STACK_ACCESS_KEY
                :url-template "http://api.ipstack.com/%s?access_key=%s&output=json&fields=country_code,region_code,latitude,longitude,continent_code"}
- :kafka       {:stock-order {:producer {:config                {:name       "stocks-order-producer"
-                                                                :brokers    #dyn/prop "KAFKA_BROKERS"
-                                                                :topic      "stocks_orders"
-                                                                :value-type :byte-array
-                                                                :shape      :value}
-                                        :channel-size-per-core #dyn/long #dyn/prop ["CHANNEL_SIZE_PER_CORE" "250"]}}}}
+ :kafka       {:stock-order {:producer {:config {"bootstrap.servers" #dyn/prop "KAFKA_BROKERS"
+                                                 "key.serializer"    "org.apache.kafka.common.serialization.ByteArraySerializer"
+                                                 "value.serializer"  "org.apache.kafka.common.serialization.ByteArraySerializer"
+                                                 "acks"              "1"
+                                                 "compression.type"  "gzip"
+                                                 "client.id"         "stocks-order-producer"}
+                                        :topic  "stocks_orders"}}}}

--- a/src/sample_donkey_api/application/protocols.clj
+++ b/src/sample_donkey_api/application/protocols.clj
@@ -8,5 +8,5 @@
   (resolve-ip [this ip] "Returns the resolved IP as a Future of a map, or a completed Future"))
 
 (defprotocol IMessagePublisher
-  (publish [this message] "Publishes an event, expected to return true if accepted")
+  (publish-stock-order [this stock-order-proto-bytes] "Publish a stock order event, expected to return a truthy promise")
   (close! [this] "Closes the output"))

--- a/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
+++ b/src/sample_donkey_api/infrastructure/repository/kafka_producer.clj
@@ -1,25 +1,23 @@
 (ns sample-donkey-api.infrastructure.repository.kafka-producer
   (:require [sample-donkey-api.application.protocols :as protocols]
-            [ketu.async.sink :as sink]
-            [clojure.core.async :as async]
-            [integrant.core :as ig]))
+            [ketu.clients.producer :as kafka-producer]
+            [integrant.core :as ig]
+            [promesa.core :as p]))
 
-(deftype ^:private KafkaProducer [channel producer]
+(deftype ^:private KafkaProducer [producer bytes->record]
   protocols/IMessagePublisher
-  (publish [_ message]
-    (async/offer! channel message))
+  (publish-stock-order [_ message-bytes]
+    (-> (kafka-producer/send! producer (bytes->record message-bytes))
+        (p/then (constantly true))))
   (close! [_]
-    (async/close! channel)))
+    (kafka-producer/close! producer 5000)))
 
-(defn- create-kafka-producer [producer-config producer-channel-size-per-core]
-  (let [available-processors (.availableProcessors (Runtime/getRuntime))
-        channel-size         (* available-processors producer-channel-size-per-core)
-        in-channel           (async/chan channel-size)]
-    (KafkaProducer. in-channel (sink/sink in-channel producer-config))))
+(defn- create-kafka-producer [stock-order-producer]
+  (let [producer (kafka-producer/producer (:config stock-order-producer))]
+    (KafkaProducer. producer (partial kafka-producer/record (:topic stock-order-producer)))))
 
 (defmethod ig/init-key :repository/stock-order-producer [_ {:keys [config]}]
-  (create-kafka-producer (-> config :kafka :stock-order :producer :config)
-                         (-> config :kafka :stock-order :producer :channel-size-per-core)))
+  (create-kafka-producer (-> config :kafka :stock-order :producer)))
 
 (defmethod ig/halt-key! :repository/stock-order-producer [_ kafka-producer]
   (protocols/close! kafka-producer))


### PR DESCRIPTION
- Use `:pedantic? :abort`
- Resolve dependency conflicts
- Update the config to a raw Kafka producer style
- kafka-procuer will now return a Future when the message is sent, the controller will now wait for it to respond back to the client
- Remove the redundant `:resource-exhausted` response code
- Use a more specific `publish-stock-order` function instead of the too-generic `publish` (to which topic/queue?)